### PR TITLE
feat: disagreement-novelty sampler

### DIFF
--- a/src/autora/experimentalist/autora_experimentalist_tutors/__init__.py
+++ b/src/autora/experimentalist/autora_experimentalist_tutors/__init__.py
@@ -1,43 +1,71 @@
-"""
-Example Experimentalist
-"""
-import numpy as np
-import pandas as pd
-
-from typing import Union, List
+from autora.experimentalist.model_disagreement import score_sample as model_disagreement_sample
+from autora.experimentalist.mixture import mixture_sample
+from autora.experimentalist.novelty import novelty_score_sample
 
 
-def sample(
-        conditions: Union[pd.DataFrame, np.ndarray],
-        models: List,
-        reference_conditions: Union[pd.DataFrame, np.ndarray],
-        num_samples: int = 1) -> pd.DataFrame:
+def disagreement_novelty_score_sample(conditions, models, reference_conditions, num_samples=1):
     """
-    Add a description of the sampler here.
+    Mixture sampling of model disagreement and novelty. If models do not agree, it means there is still more to be
+    explored in the disagreed areas. When models start to agree, we switch to novelty-based sampling. This way we
+    balance exploration and exploitation.
 
+    If scores are positive, high disagreement will be favored over novelty.
+    If model disagreement is low, novelty will be favored.
+    Negative novelty score has a weight of 0.0, therefore novelty will be favored if both scores are negative.
     Args:
-        conditions: The pool to sample from.
-            Attention: `conditions` is a field of the standard state
-        models: The sampler might use output from the theorist.
-            Attention: `models` is a field of the standard state
-        reference_conditions: The sampler might use reference conditons
-        num_samples: number of experimental conditions to select
+        conditions: pool of experimental conditions to be sampled from
+        models: models to calculate disagreement
+        reference_conditions: already sampled experimental conditions for calculating novelty
+        num_samples: number of samples to return
 
-    Returns:
-        Sampled pool of experimental conditions
-
-    *Optional*
-    Examples:
-        These examples add documentation and also work as tests
-        >>> example_sampler([1, 2, 3, 4])
-        1
-        >>> example_sampler(range(3, 10))
-        3
+    Returns: pd.DataFrame of newly sampled experimental conditions along with associated mixture score
 
     """
-    if num_samples is None:
-        num_samples = conditions.shape[0]
+    # Drop columns in reference conditions that don't match actual conditions
+    # Otherwise it doesn't work.
+    reference_cols = conditions.columns.intersection(reference_conditions.columns)
+    reference_conditions_filtered = reference_conditions[reference_cols]
 
-    new_conditions = conditions
+    params = {
+        "novelty": {
+            "reference_conditions": reference_conditions_filtered,
+        },
+        "disagreement": {
+            "models": models,
+        },
+    }
 
-    return new_conditions[:num_samples]
+    conditions = mixture_sample(
+        conditions=conditions,
+        temperature=0.01,  # Almost deterministic choice over final probabilities
+        samplers=[
+            [novelty_score_sample, "novelty", [0.2, 0.0]],
+            [model_disagreement_sample, "disagreement", [0.8, 0.1]]
+        ],
+        params=params,
+        num_samples=num_samples)
+
+    conditions.drop(columns=["score"], inplace=True)
+
+    return conditions
+
+
+def disagreement_novelty_sample(conditions, models, reference_conditions, num_samples=1):
+    """
+    Mixture sampling of model disagreement and novelty. If models do not agree, it means there is still more to be
+    explored in the disagreed areas. When models start to agree, we switch to novelty-based sampling. This way we
+    balance exploration and exploitation.
+
+    If scores are positive, high disagreement will be favored over novelty.
+    If model disagreement is low, novelty will be favored.
+    Negative novelty score has a weight of 0.0, therefore novelty will be favored if both scores are negative.
+    Args:
+        conditions: pool of experimental conditions to be sampled from
+        models: models to calculate disagreement
+        reference_conditions: already sampled experimental conditions for calculating novelty
+        num_samples: number of samples to return
+
+    Returns: pd.DataFrame of newly sampled experimental conditions
+    """
+    conditions_with_score = disagreement_novelty_score_sample(conditions, models, reference_conditions, num_samples)
+    return conditions_with_score.drop(columns=["score"])


### PR DESCRIPTION
# Description

use autora's mixture sampler to find a balanced sampling strategy between exploration & exploitation.

model disagreement is favored over novelty, as long as disagreement is high. models are shown samples that they don't agree on. this should help models converge on informative data early on.

if models can start to agree on the shown data, we explore more by using a novelty-based strategy.

# Type of change

- **feat**: A new feature
